### PR TITLE
GitHub/Workflows: Add an action to check C++ source file format 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,62 @@
+AccessModifierOffset: 0
+AlignAfterOpenBracket: DontAlign
+AlignEscapedNewlinesLeft: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: TopLevelDefinitions
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: true
+BreakBeforeBraces: Linux
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakStringLiterals: false
+ColumnLimit: 80
+CommentPragmas: '\* @'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerBinding: false
+IncludeCategories:
+  - Regex:	'.*gtest.*'
+    Priority:	-10
+  - Regex:	'".*"'
+    Priority:	10
+  - Regex:	'<.*>'
+    Priority:	0
+IndentCaseLabels: true
+IndentCaseBlocks: true
+IndentFunctionDeclarationAfterType: true
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+Language: Cpp
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 100
+PenaltyBreakComment: 100
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 100
+PenaltyExcessCharacter: 1
+PenaltyReturnTypeOnItsOwnLine: 20
+PointerBindsToType: false
+ReflowComments: false
+SpaceAfterCStyleCast: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Always
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+Standard: Cpp11
+TabWidth: 4
+UseTab: Never

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -1,0 +1,25 @@
+name: c++-source-file-format-checker
+
+on: pull_request
+
+jobs:
+  cpp-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cpp-linter/cpp-linter-action@v2
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: file
+          extensions: 'cc'
+          version: 16
+          lines-changed-only: true
+
+
+      - name: failing fast
+        if: steps.linter.outputs.clang-format-checks-failed > 0
+        run: |
+          echo "This PR failed to pass the C++ source file format checks."
+          exit 1

--- a/daemon/pipeline-dbus-impl.cc
+++ b/daemon/pipeline-dbus-impl.cc
@@ -5,14 +5,13 @@
  */
 
 /**
- * @file    pipeline-dbus-impl.cc
- * @date    20 Jul 2022
- * @brief   Implementation of pipeline dbus interface.
- * @see     https://github.com/nnstreamer/deviceMLOps.MLAgent
- * @author  Yongjoo Ahn <yongjoo1.ahn@samsung.com>
- * @bug     No known bugs except for NYI items
- * @details
- *    This implements the pipeline dbus interface.
+ * @file      pipeline-dbus-impl.cc
+ * @date      20 Jul 2022
+ * @brief     Implementation of pipeline dbus interface.
+ * @see       https://github.com/nnstreamer/deviceMLOps.MLAgent
+ * @author    Yongjoo Ahn <yongjoo1.ahn@samsung.com>
+ * @bug       No known bugs except for NYI items
+ * @details   This implements the pipeline dbus interface.
  */
 
 #include <glib.h>
@@ -412,7 +411,8 @@ dbus_cb_core_get_state (MachinelearningServicePipeline *obj,
   g_mutex_unlock (&p->lock);
 
   if (sc_ret == GST_STATE_CHANGE_FAILURE) {
-    ml_loge ("Failed to get the state of the pipline whose service name is %s.", p->service_name);
+    ml_loge ("Failed to get the state of the pipline whose service name is %s.",
+        p->service_name);
     result = -ESTRPIPE;
     machinelearning_service_pipeline_complete_get_state (obj, invoc, result, (gint) state);
     return TRUE;

--- a/daemon/resource-dbus-impl.cc
+++ b/daemon/resource-dbus-impl.cc
@@ -169,7 +169,7 @@ probe_resource_module (void *data)
 {
   int ret = 0;
 
-  ml_logd("probe_resource_module");
+  ml_logd ("probe_resource_module");
 
   g_gdbus_res_instance = gdbus_get_resource_instance ();
   if (NULL == g_gdbus_res_instance) {

--- a/daemon/service-db.cc
+++ b/daemon/service-db.cc
@@ -203,8 +203,8 @@ MLServiceDB::get_table_version (const std::string tbl_name, const int default_ve
 
   rc = sqlite3_prepare_v2 (_db, sql.c_str (), -1, &res, nullptr);
   if (rc != SQLITE_OK) {
-    ml_logw ("Failed to get the version of table %s: %s (%d)", tbl_name.c_str (),
-        sqlite3_errmsg (_db), rc);
+    ml_logw ("Failed to get the version of table %s: %s (%d)",
+        tbl_name.c_str (), sqlite3_errmsg (_db), rc);
     return -1;
   }
 

--- a/tests/daemon/unittest_gdbus_util.cc
+++ b/tests/daemon/unittest_gdbus_util.cc
@@ -28,7 +28,8 @@ class GDbusTest : public ::testing::Test
   void SetUp () override
   {
     g_autofree gchar *current_dir = g_get_current_dir ();
-    g_autofree gchar *services_dir = g_build_filename (current_dir, "tests", "services", NULL);
+    g_autofree gchar *services_dir
+        = g_build_filename (current_dir, "tests", "services", NULL);
 
     dbus = g_test_dbus_new (G_TEST_DBUS_NONE);
     ASSERT_TRUE (dbus != nullptr);

--- a/tests/daemon/unittest_ml_agent.cc
+++ b/tests/daemon/unittest_ml_agent.cc
@@ -28,7 +28,8 @@ class MLAgentTest : public ::testing::Test
   void SetUp () override
   {
     g_autofree gchar *current_dir = g_get_current_dir ();
-    g_autofree gchar *services_dir = g_build_filename (current_dir, "tests", "services", NULL);
+    g_autofree gchar *services_dir
+        = g_build_filename (current_dir, "tests", "services", NULL);
 
     dbus = g_test_dbus_new (G_TEST_DBUS_NONE);
     ASSERT_TRUE (dbus != nullptr);
@@ -248,9 +249,11 @@ TEST_F (MLAgentTest, model)
   gchar *model_info = NULL;
   gchar *str;
 
-  ret = ml_agent_model_register ("test-model", "/path/model1.tflite", TRUE, NULL, NULL, &ver1, NULL);
+  ret = ml_agent_model_register (
+      "test-model", "/path/model1.tflite", TRUE, NULL, NULL, &ver1, NULL);
   EXPECT_EQ (ret, 0);
-  ret = ml_agent_model_register ("test-model", "/path/model2.tflite", FALSE, NULL, NULL, &ver2, NULL);
+  ret = ml_agent_model_register (
+      "test-model", "/path/model2.tflite", FALSE, NULL, NULL, &ver2, NULL);
   EXPECT_EQ (ret, 0);
 
   ret = ml_agent_model_update_description ("test-model", ver1, "model1desc", NULL);
@@ -306,7 +309,8 @@ TEST_F (MLAgentTest, model_register_01_n)
   EXPECT_NE (ret, 0);
   ret = ml_agent_model_register ("test-model", "", FALSE, NULL, NULL, &ver, NULL);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_register ("test-model", "/path/model.tflite", FALSE, NULL, NULL, NULL, NULL);
+  ret = ml_agent_model_register (
+      "test-model", "/path/model.tflite", FALSE, NULL, NULL, NULL, NULL);
   EXPECT_NE (ret, 0);
 }
 
@@ -318,7 +322,8 @@ TEST_F (MLAgentTest, model_update_description_01_n)
   gint ret;
   guint ver;
 
-  ret = ml_agent_model_register ("test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
+  ret = ml_agent_model_register (
+      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
   EXPECT_EQ (ret, 0);
 
   ret = ml_agent_model_update_description (NULL, ver, "desc", NULL);
@@ -352,7 +357,8 @@ TEST_F (MLAgentTest, model_activate_01_n)
   gint ret;
   guint ver;
 
-  ret = ml_agent_model_register ("test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
+  ret = ml_agent_model_register (
+      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
   EXPECT_EQ (ret, 0);
 
   ret = ml_agent_model_activate (NULL, ver, NULL);
@@ -383,7 +389,8 @@ TEST_F (MLAgentTest, model_get_01_n)
   guint ver;
   gchar *model_info = NULL;
 
-  ret = ml_agent_model_register ("test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
+  ret = ml_agent_model_register (
+      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
   EXPECT_EQ (ret, 0);
 
   ret = ml_agent_model_get (NULL, ver, &model_info, NULL);
@@ -416,7 +423,8 @@ TEST_F (MLAgentTest, model_get_activated_01_n)
   guint ver;
   gchar *model_info = NULL;
 
-  ret = ml_agent_model_register ("test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
+  ret = ml_agent_model_register (
+      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
   EXPECT_EQ (ret, 0);
 
   ret = ml_agent_model_get_activated (NULL, &model_info, NULL);
@@ -466,7 +474,8 @@ TEST_F (MLAgentTest, model_delete_01_n)
   gint ret;
   guint ver;
 
-  ret = ml_agent_model_register ("test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
+  ret = ml_agent_model_register (
+      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
   EXPECT_EQ (ret, 0);
 
   ret = ml_agent_model_delete (NULL, ver, NULL);


### PR DESCRIPTION
This PR includes the following commits
  - Adding a GitHub Action workflow to check C++ source file format
  - Applying clang-format-16 using NNS's .clang-format to all C++ source files
  - Importing the clang-format style configuration file from the NNStreamer repository

Signed-off-by: Wook Song <wook16.song@samsung.com>


FYI, I made a PR in my forked repository to test this workflow. You can see the result [here](https://github.com/wooksong/deviceMLOps.MLAgent/pull/1).