### PR TITLE
Dist/Tizen: Introduce the machine-learning-agent-test package

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -110,13 +110,4 @@ ml_agent_conf.set('INCLUDE_INSTALL_DIR', ml_agent_install_includedir)
 
 subdir('dbus')
 subdir('daemon')
-
-# Run unittest
-if get_option('enable-test')
-  gtest_dep = dependency('gtest', required: false)
-  if gtest_dep.found()
-    subdir('tests')
-  else
-    warning('The enable-test option requires google-test.')
-  endif
-endif
+subdir('tests')

--- a/tests/daemon/meson.build
+++ b/tests/daemon/meson.build
@@ -1,3 +1,8 @@
+# Set dependency and test-env
+testenv = environment()
+testenv.set('MLAGENT_SOURCE_ROOT_PATH', meson.source_root())
+testenv.set('MLAGENT_BUILD_ROOT_PATH', meson.build_root())
+
 unittest_ml_agent = executable('unittest_ml_agent',
   'unittest_ml_agent.cc',
   dependencies: [gtest_dep, ml_agent_test_dep],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,17 +1,12 @@
 # Install path for unittest
-unittest_base_dir = join_paths(ml_agent_install_bindir, 'unittest-ml')
-unittest_install_dir = join_paths(unittest_base_dir,'tests')
-
-# Set dependency and test-env
-testenv = environment()
-testenv.set('MLAGENT_SOURCE_ROOT_PATH', meson.source_root())
-testenv.set('MLAGENT_BUILD_ROOT_PATH', meson.build_root())
+test_base_dir = join_paths(ml_agent_install_bindir, 'ml-agent-test')
+unittest_install_dir = join_paths(test_base_dir, 'unittests')
 
 ml_agent_lib_objs = ml_agent_lib.extract_objects(ml_agent_lib_srcs)
 ml_agent_test_both_lib = both_libraries('ml-agent-test',
   dependencies: ml_agent_deps,
   include_directories: ml_agent_incs,
-  install: get_option('install-test'),
+  install: true,
   install_dir: ml_agent_install_libdir,
   cpp_args: ['-DDB_PATH="."', ml_agent_db_key_prefix_arg],
   objects: ml_agent_lib_objs,
@@ -33,11 +28,19 @@ ml_agent_test_dep = declare_dependency(
 ml_agent_main_objs = ml_agent_executable.extract_objects(ml_agent_main_file)
 executable('machine-learning-agent-test',
   dependencies: ml_agent_test_dep,
-  install: get_option('install-test'),
-  install_dir: unittest_base_dir,
+  install: true,
+  install_dir: test_base_dir,
   c_args: ['-DDB_PATH="."', ml_agent_db_key_prefix_arg],
   objects: ml_agent_main_objs
 )
 
 subdir('services')
-subdir('daemon')
+# Run tests
+if get_option('enable-test')
+  gtest_dep = dependency('gtest', required: false)
+  if gtest_dep.found()
+    subdir('daemon')
+  else
+    warning('The enable-test option requires google-test.')
+  endif
+endif

--- a/tests/services/meson.build
+++ b/tests/services/meson.build
@@ -8,20 +8,18 @@ configure_file(
   configuration: builddir_cdata
 )
 
-if get_option('install-test')
-  installed_builddir_cdata = configuration_data()
-  installed_builddir_cdata.set('build_dir', unittest_base_dir)
+installed_builddir_cdata = configuration_data()
+installed_builddir_cdata.set('build_dir', test_base_dir)
 
-  test_service_file = configure_file(
-    input: test_dbus_service_file + '.in',
-    output: test_dbus_service_file + '.install',
-    configuration: installed_builddir_cdata
-  )
+test_service_file = configure_file(
+  input: test_dbus_service_file + '.in',
+  output: test_dbus_service_file + '.install',
+  configuration: installed_builddir_cdata
+)
 
-  install_data(
-    test_service_file,
-    install_dir: join_paths(unittest_install_dir, 'services'),
-    install_mode: 'rw-r--r--',
-    rename: test_dbus_service_file
-  )
-endif
+install_data(
+  test_service_file,
+  install_dir: join_paths(test_base_dir, 'services'),
+  install_mode: 'rw-r--r--',
+  rename: test_dbus_service_file
+)


### PR DESCRIPTION
This PR introduces a Tizen package that provides the ML agent for testing purposes. Several meson build scripts are updated to support it and the Tizen RPM spec file is also revised.

Signed-off-by: Wook Song <wook16.song@samsung.com>