### PR TITLE
Meson: Add workaround for a glib-2.0 (< 2.67.1) internal bug

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,10 @@ warning_c_flags = [
   '-Wdeclaration-after-statement'
 ]
 
+if glib_dep.version() < '2.67.1'
+  warning_c_flags += '-Wno-incompatible-pointer-types'
+endif
+
 # Setup warning flags for c and cpp
 foreach extra_arg : warning_flags
   if cc.has_argument (extra_arg)


### PR DESCRIPTION
Since glib-2.0( < 2.67.1) has a bug that incurs a warning, incompatible-pointer-types, on gcc (>= 11) as follows:

/usr/include/glib-2.0/glib/gatomic.h:112:5: error: argument 2 of ‘__atomic_load’ discards ‘volatile’ qualifier [-Werror=incompatible-pointer-types]
  112 |     __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST);   \
      |     ^~~~~~~~~~~~~
This patch adds a workaround for this bug to the meson build script.

Signed-off-by: Wook Song <wook16.song@samsung.com>