### PR TITLE
GitHub/Actions: Add an action building the project with GCC-13/Ubuntu

### DIFF
--- a/.github/workflows/ubuntu_gcc_native.yml
+++ b/.github/workflows/ubuntu_gcc_native.yml
@@ -1,0 +1,33 @@
+name: Native build in Ubuntu 20.04/22.04 with GCC-13
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    env:
+      BUILD_DIR: build
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, ubuntu-22.04 ]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: add a PPA for gcc-13
+      run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+    - name: install gcc-13
+      run: sudo apt-get update && sudo apt-get install -y gcc-13 g++-13
+    - name: install the meson and ninja build systems
+      run: python3 -m pip install meson ninja
+    - name: install build requirements
+      run: |
+        sudo apt-get install -y libunwind-dev libgstreamer1.0-dev libsystemd-dev \
+          libjson-glib-dev
+    - run: meson setup $BUILD_DIR
+      env:
+        CC: gcc-13
+        CXX: g++-13
+    - run: meson compile -C $BUILD_DIR
+    # TODO: Add compile time unit testing


### PR DESCRIPTION
This patch adds an action that checks the PR by building the project using GCC-13 on Ubuntu 20.04 and 22.04.

Signed-off-by: Wook Song <wook16.song@samsung.com>