### PR TITLE
Daemon/Interface: Cut the dependency on glib.h in MLOps Agent interface

### DIFF
--- a/daemon/include/mlops-agent-interface.h
+++ b/daemon/include/mlops-agent-interface.h
@@ -14,76 +14,68 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#include <glib.h>
+#include <stdint.h>
 
 /**
  * @brief An interface exported for setting the description of a pipeline.
  * @param[in] name A name indicating the pipeline whose description would be set.
  * @param[in] pipeline_desc A stringified description of the pipeline.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_pipeline_set_description (const gchar *name, const gchar *pipeline_desc, GError **err);
+int ml_agent_pipeline_set_description (const char *name, const char *pipeline_desc);
 
 /**
  * @brief An interface exported for getting the pipeline's description corresponding to the given @a name.
- * @remarks If the function succeeds, @a pipeline_desc should be released using g_free().
+ * @remarks If the function succeeds, @a pipeline_desc should be released using free().
  * @param[in] name A given name of the pipeline to get the description.
  * @param[out] pipeline_desc A stringified description of the pipeline.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_pipeline_get_description (const gchar *name, gchar **pipeline_desc, GError **err);
+int ml_agent_pipeline_get_description (const char *name, char **pipeline_desc);
 
 /**
  * @brief An interface exported for deletion of the pipeline's description corresponding to the given @a name.
  * @param[in] name A given name of the pipeline to remove the description.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_pipeline_delete (const gchar *name, GError **err);
+int ml_agent_pipeline_delete (const char *name);
 
 /**
  * @brief An interface exported for launching the pipeline's description corresponding to the given @a name.
  * @param[in] name A given name of the pipeline to launch.
  * @param[out] id A pointer of integer identifier for the launched pipeline.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_pipeline_launch (const gchar *name, gint64 *id, GError **err);
+int ml_agent_pipeline_launch (const char *name, int64_t *id);
 
 /**
  * @brief An interface exported for changing the pipeline's state of the given @a id to start.
  * @param[in] id An identifier of the launched pipeline whose state would be changed to start.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_pipeline_start (const gint64 id, GError **err);
+int ml_agent_pipeline_start (const int64_t id);
 
 /**
  * @brief An interface exported for changing the pipeline's state of the given @a id to stop.
  * @param[in] id An identifier of the launched pipeline whose state would be changed to stop.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_pipeline_stop (const gint64 id, GError **err);
+int ml_agent_pipeline_stop (const int64_t id);
 
 /**
  * @brief An interface exported for destroying a launched pipeline corresponding to the given @a id.
  * @param[in] id An identifier of the launched pipeline that would be destroyed.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_pipeline_destroy (const gint64 id, GError **err);
+int ml_agent_pipeline_destroy (const int64_t id);
 
 /**
  * @brief An interface exported for getting the pipeline's state of the given @a id.
  * @param[in] id An identifier of the launched pipeline that would be destroyed.
  * @param[out] state A pointer for the pipeline's state.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_pipeline_get_state (const gint64 id, gint *state, GError **err);
+int ml_agent_pipeline_get_state (const int64_t id, int *state);
 
 /**
  * @brief An interface exported for registering a model.
@@ -93,70 +85,65 @@ gint ml_agent_pipeline_get_state (const gint64 id, gint *state, GError **err);
  * @param[in] description A stringified description of the given model.
  * @param[in] app_info Application-specific information from Tizen's RPK.
  * @param[out] version A pointer for the version of the given model registered.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_model_register(const gchar *name, const gchar *path, const gboolean activate, const gchar *description, const gchar *app_info, guint *version, GError **err);
+int ml_agent_model_register (const char *name, const char *path, const int activate,
+    const char *description, const char *app_info, uint32_t *version);
 
 /**
  * @brief An interface exported for updating the description of the model with @a name and @a version.
  * @param[in] name A name indicating the model whose description would be updated.
  * @param[in] version A version for identifying the model whose description would be updated.
  * @param[in] description A new description to update the existing one.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_model_update_description (const gchar *name, const guint version, const gchar *description, GError **err);
+int ml_agent_model_update_description (
+    const char *name, const uint32_t version, const char *description);
 
 /**
  * @brief An interface exported for activating the model with @a name and @a version.
  * @param[in] name A name indicating a registered model.
  * @param[in] version A version of the given model, @a name.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_model_activate(const gchar *name, const guint version, GError **err);
+int ml_agent_model_activate (const char *name, const uint32_t version);
 
 /**
  * @brief An interface exported for getting the information of the model with @a name and @a version.
- * @remarks If the function succeeds, @a model_info should be released using g_free().
+ * @remarks If the function succeeds, @a model_info should be released using free().
  * @param[in] name A name indicating the model whose description would be get.
  * @param[in] version A version of the given model.
  * @param[out] model_info A pointer for the information of the given model of @a name and @a version.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_model_get(const gchar *name, const guint version, gchar **model_info, GError **err);
+int ml_agent_model_get (const char *name, const uint32_t version, char **model_info);
 
 /**
  * @brief An interface exported for getting the information of the activated model with @a name.
- * @remarks If the function succeeds, @a model_info should be released using g_free().
+ * @remarks If the function succeeds, @a model_info should be released using free().
  * @param[in] name A name indicating the model whose description would be get.
  * @param[out] model_info A pointer for the information of an activated model of the given @a name.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_model_get_activated(const gchar *name, gchar **model_info, GError **err);
+int ml_agent_model_get_activated (const char *name, char **model_info);
 
 /**
  * @brief An interface exported for getting the information of all the models corresponding to the given @a name.
- * @remarks If the function succeeds, @a model_info should be released using g_free().
+ * @remarks If the function succeeds, @a model_info should be released using free().
  * @param[in] name A name indicating the models whose description would be get.
  * @param[out] model_info A pointer for the information of all the models corresponding to the given @a name.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_model_get_all(const gchar *name, gchar **model_info, GError **err);
+int ml_agent_model_get_all (const char *name, char **model_info);
 
 /**
  * @brief An interface exported for removing the model of @a name and @a version.
  * @details If version is 0, this function removes all registered model of @a name.
  * @param[in] name A name indicating the model that would be removed.
  * @param[in] version A version for identifying a specific model.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_model_delete(const gchar *name, const guint version, GError **err);
+int ml_agent_model_delete (const char *name, const uint32_t version);
 
 /**
  * @brief An interface exported for adding the resource.
@@ -164,28 +151,26 @@ gint ml_agent_model_delete(const gchar *name, const guint version, GError **err)
  * @param[in] path A path that specifies the location of the resource.
  * @param[in] description A stringified description of the resource.
  * @param[in] app_info Application-specific information from Tizen's RPK.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_resource_add (const gchar *name, const gchar *path, const gchar *description, const gchar *app_info, GError **err);
+int ml_agent_resource_add (const char *name, const char *path,
+    const char *description, const char *app_info);
 
 /**
  * @brief An interface exported for removing the resource with @a name.
  * @param[in] name A name indicating the resource.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_resource_delete (const gchar *name, GError **err);
+int ml_agent_resource_delete (const char *name);
 
 /**
  * @brief An interface exported for getting the description of the resource with @a name.
- * @remarks If the function succeeds, @a res_info should be released using g_free().
+ * @remarks If the function succeeds, @a res_info should be released using free().
  * @param[in] name A name indicating the resource.
  * @param[out] res_info A pointer for the information of the resource.
- * @param[out] err A pointer for error, or NULL.
  * @return 0 on success, a negative error value if failed.
  */
-gint ml_agent_resource_get (const gchar *name, gchar **res_info, GError **err);
+int ml_agent_resource_get (const char *name, char **res_info);
 
 #ifdef __cplusplus
 }

--- a/daemon/mlops-agent-interface.c
+++ b/daemon/mlops-agent-interface.c
@@ -10,6 +10,7 @@
 
 #include <errno.h>
 #include <glib.h>
+#include <stdint.h>
 
 #include "include/mlops-agent-interface.h"
 #include "dbus-interface.h"
@@ -33,13 +34,12 @@ typedef gpointer ml_agent_proxy_h;
  * @brief An internal helper to get the dbus proxy
  */
 static ml_agent_proxy_h
-_get_proxy_new_for_bus_sync (ml_agent_service_type_e type, GError ** err)
+_get_proxy_new_for_bus_sync (ml_agent_service_type_e type)
 {
   static const GBusType bus_types[] = { G_BUS_TYPE_SYSTEM, G_BUS_TYPE_SESSION };
   static const size_t num_bus_types =
       sizeof (bus_types) / sizeof (bus_types[0]);
   ml_agent_proxy_h *proxy = NULL;
-  GError *_err = NULL;
   size_t i;
 
   switch (type) {
@@ -48,11 +48,9 @@ _get_proxy_new_for_bus_sync (ml_agent_service_type_e type, GError ** err)
       MachinelearningServicePipeline *mlsp;
 
       for (i = 0; i < num_bus_types; ++i) {
-        g_clear_error (&_err);
-
         mlsp = machinelearning_service_pipeline_proxy_new_for_bus_sync
             (bus_types[i], G_DBUS_PROXY_FLAGS_NONE, DBUS_ML_BUS_NAME,
-            DBUS_PIPELINE_PATH, NULL, &_err);
+            DBUS_PIPELINE_PATH, NULL, NULL);
         if (mlsp) {
           break;
         }
@@ -65,11 +63,9 @@ _get_proxy_new_for_bus_sync (ml_agent_service_type_e type, GError ** err)
       MachinelearningServiceModel *mlsm;
 
       for (i = 0; i < num_bus_types; ++i) {
-        g_clear_error (&_err);
-
         mlsm = machinelearning_service_model_proxy_new_for_bus_sync
             (bus_types[i], G_DBUS_PROXY_FLAGS_NONE, DBUS_ML_BUS_NAME,
-            DBUS_MODEL_PATH, NULL, &_err);
+            DBUS_MODEL_PATH, NULL, NULL);
         if (mlsm)
           break;
       }
@@ -81,11 +77,9 @@ _get_proxy_new_for_bus_sync (ml_agent_service_type_e type, GError ** err)
       MachinelearningServiceResource *mlsr;
 
       for (i = 0; i < num_bus_types; ++i) {
-        g_clear_error (&_err);
-
         mlsr = machinelearning_service_resource_proxy_new_for_bus_sync
             (bus_types[i], G_DBUS_PROXY_FLAGS_NONE, DBUS_ML_BUS_NAME,
-            DBUS_RESOURCE_PATH, NULL, &_err);
+            DBUS_RESOURCE_PATH, NULL, NULL);
         if (mlsr)
           break;
       }
@@ -96,20 +90,14 @@ _get_proxy_new_for_bus_sync (ml_agent_service_type_e type, GError ** err)
       break;
   }
 
-  if (_err) {
-    *err = g_error_copy (_err);
-    g_clear_error (&_err);
-  }
-
   return proxy;
 }
 
 /**
  * @brief An interface exported for setting the description of a pipeline.
  */
-gint
-ml_agent_pipeline_set_description (const gchar * name,
-    const gchar * pipeline_desc, GError ** err)
+int
+ml_agent_pipeline_set_description (const char *name, const char *pipeline_desc)
 {
   MachinelearningServicePipeline *mlsp;
   gboolean result;
@@ -118,13 +106,13 @@ ml_agent_pipeline_set_description (const gchar * name,
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE, err);
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE);
   if (!mlsp) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_pipeline_call_set_pipeline_sync (mlsp,
-      name, pipeline_desc, NULL, NULL, err);
+      name, pipeline_desc, NULL, NULL, NULL);
   g_object_unref (mlsp);
 
   g_return_val_if_fail (result, -EIO);
@@ -134,9 +122,8 @@ ml_agent_pipeline_set_description (const gchar * name,
 /**
  * @brief An interface exported for getting the pipeline's description corresponding to the given @a name.
  */
-gint
-ml_agent_pipeline_get_description (const gchar * name,
-    gchar ** pipeline_desc, GError ** err)
+int
+ml_agent_pipeline_get_description (const char *name, char **pipeline_desc)
 {
   MachinelearningServicePipeline *mlsp;
   gboolean result;
@@ -146,13 +133,13 @@ ml_agent_pipeline_get_description (const gchar * name,
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE, err);
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE);
   if (!mlsp) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_pipeline_call_get_pipeline_sync (mlsp,
-      name, &ret, pipeline_desc, NULL, err);
+      name, &ret, pipeline_desc, NULL, NULL);
   g_object_unref (mlsp);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -162,8 +149,8 @@ ml_agent_pipeline_get_description (const gchar * name,
 /**
  * @brief An interface exported for deletion of the pipeline's description corresponding to the given @a name.
  */
-gint
-ml_agent_pipeline_delete (const gchar * name, GError ** err)
+int
+ml_agent_pipeline_delete (const char *name)
 {
   MachinelearningServicePipeline *mlsp;
   gboolean result;
@@ -173,13 +160,13 @@ ml_agent_pipeline_delete (const gchar * name, GError ** err)
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE, err);
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE);
   if (!mlsp) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_pipeline_call_delete_pipeline_sync (mlsp,
-      name, &ret, NULL, err);
+      name, &ret, NULL, NULL);
   g_object_unref (mlsp);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -189,8 +176,8 @@ ml_agent_pipeline_delete (const gchar * name, GError ** err)
 /**
  * @brief An interface exported for launching the pipeline's description corresponding to the given @a name.
  */
-gint
-ml_agent_pipeline_launch (const gchar * name, gint64 * id, GError ** err)
+int
+ml_agent_pipeline_launch (const char *name, int64_t * id)
 {
   MachinelearningServicePipeline *mlsp;
   gboolean result;
@@ -200,13 +187,13 @@ ml_agent_pipeline_launch (const gchar * name, gint64 * id, GError ** err)
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE, err);
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE);
   if (!mlsp) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_pipeline_call_launch_pipeline_sync (mlsp,
-      name, &ret, id, NULL, err);
+      name, &ret, id, NULL, NULL);
   g_object_unref (mlsp);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -216,20 +203,20 @@ ml_agent_pipeline_launch (const gchar * name, gint64 * id, GError ** err)
 /**
  * @brief An interface exported for changing the pipeline's state of the given @a id to start.
  */
-gint
-ml_agent_pipeline_start (const gint64 id, GError ** err)
+int
+ml_agent_pipeline_start (const int64_t id)
 {
   MachinelearningServicePipeline *mlsp;
   gboolean result;
   gint ret;
 
-  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE, err);
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE);
   if (!mlsp) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_pipeline_call_start_pipeline_sync (mlsp,
-      id, &ret, NULL, err);
+      id, &ret, NULL, NULL);
   g_object_unref (mlsp);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -239,20 +226,20 @@ ml_agent_pipeline_start (const gint64 id, GError ** err)
 /**
  * @brief An interface exported for changing the pipeline's state of the given @a id to stop.
  */
-gint
-ml_agent_pipeline_stop (const gint64 id, GError ** err)
+int
+ml_agent_pipeline_stop (const int64_t id)
 {
   MachinelearningServicePipeline *mlsp;
   gboolean result;
   gint ret;
 
-  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE, err);
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE);
   if (!mlsp) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_pipeline_call_stop_pipeline_sync (mlsp,
-      id, &ret, NULL, err);
+      id, &ret, NULL, NULL);
   g_object_unref (mlsp);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -262,20 +249,20 @@ ml_agent_pipeline_stop (const gint64 id, GError ** err)
 /**
  * @brief An interface exported for destroying a launched pipeline corresponding to the given @a id.
  */
-gint
-ml_agent_pipeline_destroy (const gint64 id, GError ** err)
+int
+ml_agent_pipeline_destroy (const int64_t id)
 {
   MachinelearningServicePipeline *mlsp;
   gboolean result;
   gint ret;
 
-  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE, err);
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE);
   if (!mlsp) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_pipeline_call_destroy_pipeline_sync (mlsp,
-      id, &ret, NULL, err);
+      id, &ret, NULL, NULL);
   g_object_unref (mlsp);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -285,8 +272,8 @@ ml_agent_pipeline_destroy (const gint64 id, GError ** err)
 /**
  * @brief An interface exported for getting the pipeline's state of the given @a id.
  */
-gint
-ml_agent_pipeline_get_state (const gint64 id, gint * state, GError ** err)
+int
+ml_agent_pipeline_get_state (const int64_t id, int *state)
 {
   MachinelearningServicePipeline *mlsp;
   gboolean result;
@@ -296,13 +283,13 @@ ml_agent_pipeline_get_state (const gint64 id, gint * state, GError ** err)
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE, err);
+  mlsp = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_PIPELINE);
   if (!mlsp) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_pipeline_call_get_state_sync (mlsp,
-      id, &ret, state, NULL, err);
+      id, &ret, state, NULL, NULL);
   g_object_unref (mlsp);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -312,10 +299,10 @@ ml_agent_pipeline_get_state (const gint64 id, gint * state, GError ** err)
 /**
  * @brief An interface exported for registering a model.
  */
-gint
-ml_agent_model_register (const gchar * name, const gchar * path,
-    const gboolean activate, const gchar * description, const gchar * app_info,
-    guint * version, GError ** err)
+int
+ml_agent_model_register (const char *name, const char *path,
+    const int activate, const char *description, const char *app_info,
+    uint32_t * version)
 {
   MachinelearningServiceModel *mlsm;
   gboolean result;
@@ -325,14 +312,14 @@ ml_agent_model_register (const gchar * name, const gchar * path,
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL, err);
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL);
   if (!mlsm) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_model_call_register_sync (mlsm, name, path,
       activate, description ? description : "", app_info ? app_info : "",
-      version, &ret, NULL, err);
+      version, &ret, NULL, NULL);
   g_object_unref (mlsm);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -342,9 +329,9 @@ ml_agent_model_register (const gchar * name, const gchar * path,
 /**
  * @brief An interface exported for updating the description of the model with @a name and @a version.
  */
-gint
-ml_agent_model_update_description (const gchar * name,
-    const guint version, const gchar * description, GError ** err)
+int
+ml_agent_model_update_description (const char *name,
+    const uint32_t version, const char *description)
 {
   MachinelearningServiceModel *mlsm;
   gboolean result;
@@ -354,13 +341,13 @@ ml_agent_model_update_description (const gchar * name,
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL, err);
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL);
   if (!mlsm) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_model_call_update_description_sync (mlsm,
-      name, version, description, &ret, NULL, err);
+      name, version, description, &ret, NULL, NULL);
   g_object_unref (mlsm);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -370,8 +357,8 @@ ml_agent_model_update_description (const gchar * name,
 /**
  * @brief An interface exported for activating the model with @a name and @a version.
  */
-gint
-ml_agent_model_activate (const gchar * name, const guint version, GError ** err)
+int
+ml_agent_model_activate (const char *name, const uint32_t version)
 {
   MachinelearningServiceModel *mlsm;
   gboolean result;
@@ -381,13 +368,13 @@ ml_agent_model_activate (const gchar * name, const guint version, GError ** err)
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL, err);
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL);
   if (!mlsm) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_model_call_activate_sync (mlsm,
-      name, version, &ret, NULL, err);
+      name, version, &ret, NULL, NULL);
   g_object_unref (mlsm);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -397,9 +384,8 @@ ml_agent_model_activate (const gchar * name, const guint version, GError ** err)
 /**
  * @brief An interface exported for getting the information of the model with @a name and @a version.
  */
-gint
-ml_agent_model_get (const gchar * name, const guint version,
-    gchar ** model_info, GError ** err)
+int
+ml_agent_model_get (const char *name, const uint32_t version, char **model_info)
 {
   MachinelearningServiceModel *mlsm;
   gboolean result;
@@ -409,13 +395,13 @@ ml_agent_model_get (const gchar * name, const guint version,
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL, err);
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL);
   if (!mlsm) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_model_call_get_sync (mlsm,
-      name, version, model_info, &ret, NULL, err);
+      name, version, model_info, &ret, NULL, NULL);
   g_object_unref (mlsm);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -425,9 +411,8 @@ ml_agent_model_get (const gchar * name, const guint version,
 /**
  * @brief An interface exported for getting the information of the activated model with @a name.
  */
-gint
-ml_agent_model_get_activated (const gchar * name,
-    gchar ** model_info, GError ** err)
+int
+ml_agent_model_get_activated (const char *name, char **model_info)
 {
   MachinelearningServiceModel *mlsm;
   gboolean result;
@@ -437,13 +422,13 @@ ml_agent_model_get_activated (const gchar * name,
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL, err);
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL);
   if (!mlsm) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_model_call_get_activated_sync (mlsm,
-      name, model_info, &ret, NULL, err);
+      name, model_info, &ret, NULL, NULL);
   g_object_unref (mlsm);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -453,8 +438,8 @@ ml_agent_model_get_activated (const gchar * name,
 /**
  * @brief An interface exported for getting the information of all the models corresponding to the given @a name.
  */
-gint
-ml_agent_model_get_all (const gchar * name, gchar ** model_info, GError ** err)
+int
+ml_agent_model_get_all (const char *name, char **model_info)
 {
   MachinelearningServiceModel *mlsm;
   gboolean result;
@@ -464,13 +449,13 @@ ml_agent_model_get_all (const gchar * name, gchar ** model_info, GError ** err)
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL, err);
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL);
   if (!mlsm) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_model_call_get_all_sync (mlsm,
-      name, model_info, &ret, NULL, err);
+      name, model_info, &ret, NULL, NULL);
   g_object_unref (mlsm);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -480,8 +465,8 @@ ml_agent_model_get_all (const gchar * name, gchar ** model_info, GError ** err)
 /**
  * @brief An interface exported for removing the model of @a name and @a version.
  */
-gint
-ml_agent_model_delete (const gchar * name, const guint version, GError ** err)
+int
+ml_agent_model_delete (const char *name, const uint32_t version)
 {
   MachinelearningServiceModel *mlsm;
   gboolean result;
@@ -491,13 +476,13 @@ ml_agent_model_delete (const gchar * name, const guint version, GError ** err)
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL, err);
+  mlsm = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_MODEL);
   if (!mlsm) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_model_call_delete_sync (mlsm,
-      name, version, &ret, NULL, err);
+      name, version, &ret, NULL, NULL);
   g_object_unref (mlsm);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -507,9 +492,9 @@ ml_agent_model_delete (const gchar * name, const guint version, GError ** err)
 /**
  * @brief An interface exported for adding the resource.
  */
-gint
-ml_agent_resource_add (const gchar * name, const gchar * path,
-    const gchar * description, const gchar * app_info, GError ** err)
+int
+ml_agent_resource_add (const char *name, const char *path,
+    const char *description, const char *app_info)
 {
   MachinelearningServiceResource *mlsr;
   gboolean result;
@@ -519,14 +504,14 @@ ml_agent_resource_add (const gchar * name, const gchar * path,
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsr = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_RESOURCE, err);
+  mlsr = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_RESOURCE);
   if (!mlsr) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_resource_call_add_sync (mlsr, name, path,
       description ? description : "", app_info ? app_info : "",
-      &ret, NULL, err);
+      &ret, NULL, NULL);
   g_object_unref (mlsr);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -536,8 +521,8 @@ ml_agent_resource_add (const gchar * name, const gchar * path,
 /**
  * @brief An interface exported for removing the resource with @a name.
  */
-gint
-ml_agent_resource_delete (const gchar * name, GError ** err)
+int
+ml_agent_resource_delete (const char *name)
 {
   MachinelearningServiceResource *mlsr;
   gboolean result;
@@ -547,13 +532,13 @@ ml_agent_resource_delete (const gchar * name, GError ** err)
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsr = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_RESOURCE, err);
+  mlsr = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_RESOURCE);
   if (!mlsr) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_resource_call_delete_sync (mlsr,
-      name, &ret, NULL, err);
+      name, &ret, NULL, NULL);
   g_object_unref (mlsr);
 
   g_return_val_if_fail (ret == 0 && result, ret);
@@ -563,8 +548,8 @@ ml_agent_resource_delete (const gchar * name, GError ** err)
 /**
  * @brief An interface exported for getting the description of the resource with @a name.
  */
-gint
-ml_agent_resource_get (const gchar * name, gchar ** res_info, GError ** err)
+int
+ml_agent_resource_get (const char *name, char **res_info)
 {
   MachinelearningServiceResource *mlsr;
   gboolean result;
@@ -574,13 +559,13 @@ ml_agent_resource_get (const gchar * name, gchar ** res_info, GError ** err)
     g_return_val_if_reached (-EINVAL);
   }
 
-  mlsr = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_RESOURCE, err);
+  mlsr = _get_proxy_new_for_bus_sync (ML_AGENT_SERVICE_RESOURCE);
   if (!mlsr) {
     g_return_val_if_reached (-EIO);
   }
 
   result = machinelearning_service_resource_call_get_sync (mlsr,
-      name, res_info, &ret, NULL, err);
+      name, res_info, &ret, NULL, NULL);
   g_object_unref (mlsr);
 
   g_return_val_if_fail (ret == 0 && result, ret);

--- a/tests/daemon/unittest_mlops_agent.cc
+++ b/tests/daemon/unittest_mlops_agent.cc
@@ -62,34 +62,34 @@ TEST_F (MLAgentTest, pipeline)
   gint64 id;
   gchar *desc = NULL;
 
-  ret = ml_agent_pipeline_set_description ("test-pipeline", pipeline_desc, NULL);
+  ret = ml_agent_pipeline_set_description ("test-pipeline", pipeline_desc);
   EXPECT_EQ (ret, 0);
 
-  ret = ml_agent_pipeline_get_description ("test-pipeline", &desc, NULL);
+  ret = ml_agent_pipeline_get_description ("test-pipeline", &desc);
   EXPECT_EQ (ret, 0);
   EXPECT_STREQ (desc, pipeline_desc);
   g_free (desc);
 
-  ret = ml_agent_pipeline_launch ("test-pipeline", &id, NULL);
+  ret = ml_agent_pipeline_launch ("test-pipeline", &id);
   EXPECT_EQ (ret, 0);
 
-  ret = ml_agent_pipeline_start (id, NULL);
-  EXPECT_EQ (ret, 0);
-  g_usleep (200000);
-
-  ret = ml_agent_pipeline_stop (id, NULL);
+  ret = ml_agent_pipeline_start (id);
   EXPECT_EQ (ret, 0);
   g_usleep (200000);
 
-  ret = ml_agent_pipeline_get_state (id, &state, NULL);
+  ret = ml_agent_pipeline_stop (id);
   EXPECT_EQ (ret, 0);
   g_usleep (200000);
 
-  ret = ml_agent_pipeline_destroy (id, NULL);
+  ret = ml_agent_pipeline_get_state (id, &state);
   EXPECT_EQ (ret, 0);
   g_usleep (200000);
 
-  ret = ml_agent_pipeline_delete ("test-pipeline", NULL);
+  ret = ml_agent_pipeline_destroy (id);
+  EXPECT_EQ (ret, 0);
+  g_usleep (200000);
+
+  ret = ml_agent_pipeline_delete ("test-pipeline");
   EXPECT_EQ (ret, 0);
 }
 
@@ -100,13 +100,13 @@ TEST_F (MLAgentTest, pipeline_set_description_01_n)
 {
   gint ret;
 
-  ret = ml_agent_pipeline_set_description (NULL, "fakesrc ! fakesink", NULL);
+  ret = ml_agent_pipeline_set_description (NULL, "fakesrc ! fakesink");
   EXPECT_NE (ret, 0);
-  ret = ml_agent_pipeline_set_description ("", "fakesrc ! fakesink", NULL);
+  ret = ml_agent_pipeline_set_description ("", "fakesrc ! fakesink");
   EXPECT_NE (ret, 0);
-  ret = ml_agent_pipeline_set_description ("test-pipeline", NULL, NULL);
+  ret = ml_agent_pipeline_set_description ("test-pipeline", NULL);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_pipeline_set_description ("test-pipeline", "", NULL);
+  ret = ml_agent_pipeline_set_description ("test-pipeline", "");
   EXPECT_NE (ret, 0);
 }
 
@@ -118,15 +118,15 @@ TEST_F (MLAgentTest, pipeline_get_description_01_n)
   gint ret;
   gchar *desc = NULL;
 
-  ret = ml_agent_pipeline_get_description (NULL, &desc, NULL);
+  ret = ml_agent_pipeline_get_description (NULL, &desc);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_pipeline_get_description ("", &desc, NULL);
+  ret = ml_agent_pipeline_get_description ("", &desc);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_pipeline_get_description ("test-pipeline", NULL, NULL);
+  ret = ml_agent_pipeline_get_description ("test-pipeline", NULL);
   EXPECT_NE (ret, 0);
 
   /* no registered pipeline */
-  ret = ml_agent_pipeline_get_description ("test-pipeline", &desc, NULL);
+  ret = ml_agent_pipeline_get_description ("test-pipeline", &desc);
   EXPECT_NE (ret, 0);
 }
 
@@ -137,13 +137,13 @@ TEST_F (MLAgentTest, pipeline_delete_01_n)
 {
   gint ret;
 
-  ret = ml_agent_pipeline_delete (NULL, NULL);
+  ret = ml_agent_pipeline_delete (NULL);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_pipeline_delete ("", NULL);
+  ret = ml_agent_pipeline_delete ("");
   EXPECT_NE (ret, 0);
 
   /* no registered pipeline */
-  ret = ml_agent_pipeline_delete ("test-pipeline", NULL);
+  ret = ml_agent_pipeline_delete ("test-pipeline");
   EXPECT_NE (ret, 0);
 }
 
@@ -155,15 +155,15 @@ TEST_F (MLAgentTest, pipeline_launch_01_n)
   gint ret;
   gint64 id;
 
-  ret = ml_agent_pipeline_launch (NULL, &id, NULL);
+  ret = ml_agent_pipeline_launch (NULL, &id);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_pipeline_launch ("", &id, NULL);
+  ret = ml_agent_pipeline_launch ("", &id);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_pipeline_launch ("test-pipeline", NULL, NULL);
+  ret = ml_agent_pipeline_launch ("test-pipeline", NULL);
   EXPECT_NE (ret, 0);
 
   /* no registered pipeline */
-  ret = ml_agent_pipeline_launch ("test-pipeline", &id, NULL);
+  ret = ml_agent_pipeline_launch ("test-pipeline", &id);
   EXPECT_NE (ret, 0);
 }
 
@@ -175,7 +175,7 @@ TEST_F (MLAgentTest, pipeline_start_01_n)
   gint ret;
 
   /* invalid id */
-  ret = ml_agent_pipeline_start (-1, NULL);
+  ret = ml_agent_pipeline_start (-1);
   EXPECT_NE (ret, 0);
 }
 
@@ -187,7 +187,7 @@ TEST_F (MLAgentTest, pipeline_stop_01_n)
   gint ret;
 
   /* invalid id */
-  ret = ml_agent_pipeline_stop (-1, NULL);
+  ret = ml_agent_pipeline_stop (-1);
   EXPECT_NE (ret, 0);
 }
 
@@ -199,7 +199,7 @@ TEST_F (MLAgentTest, pipeline_destroy_01_n)
   gint ret;
 
   /* invalid id */
-  ret = ml_agent_pipeline_destroy (-1, NULL);
+  ret = ml_agent_pipeline_destroy (-1);
   EXPECT_NE (ret, 0);
 }
 
@@ -212,30 +212,30 @@ TEST_F (MLAgentTest, pipeline_get_state_01_n)
   gint state;
   gint64 id;
 
-  ret = ml_agent_pipeline_set_description ("test-pipeline", "fakesrc ! fakesink", NULL);
+  ret = ml_agent_pipeline_set_description ("test-pipeline", "fakesrc ! fakesink");
   EXPECT_EQ (ret, 0);
 
-  ret = ml_agent_pipeline_launch ("test-pipeline", &id, NULL);
+  ret = ml_agent_pipeline_launch ("test-pipeline", &id);
   EXPECT_EQ (ret, 0);
   g_usleep (200000);
 
-  ret = ml_agent_pipeline_get_state (id, NULL, NULL);
+  ret = ml_agent_pipeline_get_state (id, NULL);
   EXPECT_NE (ret, 0);
 
   /* invalid id */
-  ret = ml_agent_pipeline_get_state (-1, &state, NULL);
+  ret = ml_agent_pipeline_get_state (-1, &state);
   EXPECT_NE (ret, 0);
 
-  ret = ml_agent_pipeline_destroy (id, NULL);
+  ret = ml_agent_pipeline_destroy (id);
   EXPECT_EQ (ret, 0);
   g_usleep (200000);
 
-  ret = ml_agent_pipeline_delete ("test-pipeline", NULL);
+  ret = ml_agent_pipeline_delete ("test-pipeline");
   EXPECT_EQ (ret, 0);
   g_usleep (200000);
 
   /* no registered pipeline */
-  ret = ml_agent_pipeline_get_state (id, &state, NULL);
+  ret = ml_agent_pipeline_get_state (id, &state);
   EXPECT_NE (ret, 0);
 }
 
@@ -250,16 +250,16 @@ TEST_F (MLAgentTest, model)
   gchar *str;
 
   ret = ml_agent_model_register (
-      "test-model", "/path/model1.tflite", TRUE, NULL, NULL, &ver1, NULL);
+      "test-model", "/path/model1.tflite", TRUE, NULL, NULL, &ver1);
   EXPECT_EQ (ret, 0);
   ret = ml_agent_model_register (
-      "test-model", "/path/model2.tflite", FALSE, NULL, NULL, &ver2, NULL);
+      "test-model", "/path/model2.tflite", FALSE, NULL, NULL, &ver2);
   EXPECT_EQ (ret, 0);
 
-  ret = ml_agent_model_update_description ("test-model", ver1, "model1desc", NULL);
+  ret = ml_agent_model_update_description ("test-model", ver1, "model1desc");
   EXPECT_EQ (ret, 0);
 
-  ret = ml_agent_model_get ("test-model", ver1, &model_info, NULL);
+  ret = ml_agent_model_get ("test-model", ver1, &model_info);
   EXPECT_EQ (ret, 0);
 
   str = (model_info != NULL) ? strstr (model_info, "/path/model1.tflite") : NULL;
@@ -269,9 +269,9 @@ TEST_F (MLAgentTest, model)
   g_free (model_info);
   model_info = NULL;
 
-  ret = ml_agent_model_activate ("test-model", ver2, NULL);
+  ret = ml_agent_model_activate ("test-model", ver2);
   EXPECT_EQ (ret, 0);
-  ret = ml_agent_model_get_activated ("test-model", &model_info, NULL);
+  ret = ml_agent_model_get_activated ("test-model", &model_info);
   EXPECT_EQ (ret, 0);
 
   str = (model_info != NULL) ? strstr (model_info, "/path/model2.tflite") : NULL;
@@ -279,7 +279,7 @@ TEST_F (MLAgentTest, model)
   g_free (model_info);
   model_info = NULL;
 
-  ret = ml_agent_model_get_all ("test-model", &model_info, NULL);
+  ret = ml_agent_model_get_all ("test-model", &model_info);
   EXPECT_EQ (ret, 0);
 
   str = (model_info != NULL) ? strstr (model_info, "/path/model1.tflite") : NULL;
@@ -289,7 +289,7 @@ TEST_F (MLAgentTest, model)
   g_free (model_info);
   model_info = NULL;
 
-  ret = ml_agent_model_delete ("test-model", 0U, NULL);
+  ret = ml_agent_model_delete ("test-model", 0U);
   EXPECT_EQ (ret, 0);
 }
 
@@ -301,16 +301,15 @@ TEST_F (MLAgentTest, model_register_01_n)
   gint ret;
   guint ver;
 
-  ret = ml_agent_model_register (NULL, "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
+  ret = ml_agent_model_register (NULL, "/path/model.tflite", FALSE, NULL, NULL, &ver);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_register ("", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
+  ret = ml_agent_model_register ("", "/path/model.tflite", FALSE, NULL, NULL, &ver);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_register ("test-model", NULL, FALSE, NULL, NULL, &ver, NULL);
+  ret = ml_agent_model_register ("test-model", NULL, FALSE, NULL, NULL, &ver);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_register ("test-model", "", FALSE, NULL, NULL, &ver, NULL);
+  ret = ml_agent_model_register ("test-model", "", FALSE, NULL, NULL, &ver);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_register (
-      "test-model", "/path/model.tflite", FALSE, NULL, NULL, NULL, NULL);
+  ret = ml_agent_model_register ("test-model", "/path/model.tflite", FALSE, NULL, NULL, NULL);
   EXPECT_NE (ret, 0);
 }
 
@@ -323,29 +322,29 @@ TEST_F (MLAgentTest, model_update_description_01_n)
   guint ver;
 
   ret = ml_agent_model_register (
-      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
+      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver);
   EXPECT_EQ (ret, 0);
 
-  ret = ml_agent_model_update_description (NULL, ver, "desc", NULL);
+  ret = ml_agent_model_update_description (NULL, ver, "desc");
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_update_description ("", ver, "desc", NULL);
+  ret = ml_agent_model_update_description ("", ver, "desc");
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_update_description ("test-model", 0U, "desc", NULL);
+  ret = ml_agent_model_update_description ("test-model", 0U, "desc");
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_update_description ("test-model", ver, NULL, NULL);
+  ret = ml_agent_model_update_description ("test-model", ver, NULL);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_update_description ("test-model", ver, "", NULL);
+  ret = ml_agent_model_update_description ("test-model", ver, "");
   EXPECT_NE (ret, 0);
 
   /* invalid version */
-  ret = ml_agent_model_update_description ("test-model", (ver + 5U), "desc", NULL);
+  ret = ml_agent_model_update_description ("test-model", (ver + 5U), "desc");
   EXPECT_NE (ret, 0);
 
-  ret = ml_agent_model_delete ("test-model", 0U, NULL);
+  ret = ml_agent_model_delete ("test-model", 0U);
   EXPECT_EQ (ret, 0);
 
   /* no registered model */
-  ret = ml_agent_model_update_description ("test-model", ver, "desc", NULL);
+  ret = ml_agent_model_update_description ("test-model", ver, "desc");
   EXPECT_NE (ret, 0);
 }
 
@@ -358,25 +357,25 @@ TEST_F (MLAgentTest, model_activate_01_n)
   guint ver;
 
   ret = ml_agent_model_register (
-      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
+      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver);
   EXPECT_EQ (ret, 0);
 
-  ret = ml_agent_model_activate (NULL, ver, NULL);
+  ret = ml_agent_model_activate (NULL, ver);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_activate ("", ver, NULL);
+  ret = ml_agent_model_activate ("", ver);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_activate ("test-model", 0U, NULL);
+  ret = ml_agent_model_activate ("test-model", 0U);
   EXPECT_NE (ret, 0);
 
   /* invalid version */
-  ret = ml_agent_model_activate ("test-model", (ver + 5U), NULL);
+  ret = ml_agent_model_activate ("test-model", (ver + 5U));
   EXPECT_NE (ret, 0);
 
-  ret = ml_agent_model_delete ("test-model", 0U, NULL);
+  ret = ml_agent_model_delete ("test-model", 0U);
   EXPECT_EQ (ret, 0);
 
   /* no registered model */
-  ret = ml_agent_model_activate ("test-model", ver, NULL);
+  ret = ml_agent_model_activate ("test-model", ver);
   EXPECT_NE (ret, 0);
 }
 
@@ -390,27 +389,27 @@ TEST_F (MLAgentTest, model_get_01_n)
   gchar *model_info = NULL;
 
   ret = ml_agent_model_register (
-      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
+      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver);
   EXPECT_EQ (ret, 0);
 
-  ret = ml_agent_model_get (NULL, ver, &model_info, NULL);
+  ret = ml_agent_model_get (NULL, ver, &model_info);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_get ("", ver, &model_info, NULL);
+  ret = ml_agent_model_get ("", ver, &model_info);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_get ("test-model", 0U, &model_info, NULL);
+  ret = ml_agent_model_get ("test-model", 0U, &model_info);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_get ("test-model", ver, NULL, NULL);
+  ret = ml_agent_model_get ("test-model", ver, NULL);
   EXPECT_NE (ret, 0);
 
   /* invalid version */
-  ret = ml_agent_model_get ("test-model", (ver + 5U), &model_info, NULL);
+  ret = ml_agent_model_get ("test-model", (ver + 5U), &model_info);
   EXPECT_NE (ret, 0);
 
-  ret = ml_agent_model_delete ("test-model", 0U, NULL);
+  ret = ml_agent_model_delete ("test-model", 0U);
   EXPECT_EQ (ret, 0);
 
   /* no registered model */
-  ret = ml_agent_model_get ("test-model", ver, &model_info, NULL);
+  ret = ml_agent_model_get ("test-model", ver, &model_info);
   EXPECT_NE (ret, 0);
 }
 
@@ -424,25 +423,25 @@ TEST_F (MLAgentTest, model_get_activated_01_n)
   gchar *model_info = NULL;
 
   ret = ml_agent_model_register (
-      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
+      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver);
   EXPECT_EQ (ret, 0);
 
-  ret = ml_agent_model_get_activated (NULL, &model_info, NULL);
+  ret = ml_agent_model_get_activated (NULL, &model_info);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_get_activated ("", &model_info, NULL);
+  ret = ml_agent_model_get_activated ("", &model_info);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_get_activated ("test-model", NULL, NULL);
+  ret = ml_agent_model_get_activated ("test-model", NULL);
   EXPECT_NE (ret, 0);
 
   /* no activated model */
-  ret = ml_agent_model_get_activated ("test-model", &model_info, NULL);
+  ret = ml_agent_model_get_activated ("test-model", &model_info);
   EXPECT_NE (ret, 0);
 
-  ret = ml_agent_model_delete ("test-model", 0U, NULL);
+  ret = ml_agent_model_delete ("test-model", 0U);
   EXPECT_EQ (ret, 0);
 
   /* no registered model */
-  ret = ml_agent_model_get_activated ("test-model", &model_info, NULL);
+  ret = ml_agent_model_get_activated ("test-model", &model_info);
   EXPECT_NE (ret, 0);
 }
 
@@ -454,15 +453,15 @@ TEST_F (MLAgentTest, model_get_all_01_n)
   gint ret;
   gchar *model_info = NULL;
 
-  ret = ml_agent_model_get_all (NULL, &model_info, NULL);
+  ret = ml_agent_model_get_all (NULL, &model_info);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_get_all ("", &model_info, NULL);
+  ret = ml_agent_model_get_all ("", &model_info);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_get_all ("test-model", NULL, NULL);
+  ret = ml_agent_model_get_all ("test-model", NULL);
   EXPECT_NE (ret, 0);
 
   /* no registered model */
-  ret = ml_agent_model_get_all ("test-model", &model_info, NULL);
+  ret = ml_agent_model_get_all ("test-model", &model_info);
   EXPECT_NE (ret, 0);
 }
 
@@ -475,23 +474,23 @@ TEST_F (MLAgentTest, model_delete_01_n)
   guint ver;
 
   ret = ml_agent_model_register (
-      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver, NULL);
+      "test-model", "/path/model.tflite", FALSE, NULL, NULL, &ver);
   EXPECT_EQ (ret, 0);
 
-  ret = ml_agent_model_delete (NULL, ver, NULL);
+  ret = ml_agent_model_delete (NULL, ver);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_model_delete ("", ver, NULL);
+  ret = ml_agent_model_delete ("", ver);
   EXPECT_NE (ret, 0);
 
   /* invalid version */
-  ret = ml_agent_model_delete ("test-model", (ver + 5U), NULL);
+  ret = ml_agent_model_delete ("test-model", (ver + 5U));
   EXPECT_NE (ret, 0);
 
-  ret = ml_agent_model_delete ("test-model", 0U, NULL);
+  ret = ml_agent_model_delete ("test-model", 0U);
   EXPECT_EQ (ret, 0);
 
   /* no registered model */
-  ret = ml_agent_model_delete ("test-model", 0U, NULL);
+  ret = ml_agent_model_delete ("test-model", 0U);
   EXPECT_NE (ret, 0);
 }
 
@@ -504,10 +503,10 @@ TEST_F (MLAgentTest, resource)
   gchar *res_info = NULL;
   gchar *str;
 
-  ret = ml_agent_resource_add ("test-res", "/path/res1.dat", NULL, NULL, NULL);
+  ret = ml_agent_resource_add ("test-res", "/path/res1.dat", NULL, NULL);
   EXPECT_EQ (ret, 0);
 
-  ret = ml_agent_resource_get ("test-res", &res_info, NULL);
+  ret = ml_agent_resource_get ("test-res", &res_info);
   EXPECT_EQ (ret, 0);
 
   str = (res_info != NULL) ? strstr (res_info, "/path/res1.dat") : NULL;
@@ -517,10 +516,10 @@ TEST_F (MLAgentTest, resource)
   g_free (res_info);
   res_info = NULL;
 
-  ret = ml_agent_resource_add ("test-res", "/path/res2.dat", "res2desc", NULL, NULL);
+  ret = ml_agent_resource_add ("test-res", "/path/res2.dat", "res2desc", NULL);
   EXPECT_EQ (ret, 0);
 
-  ret = ml_agent_resource_get ("test-res", &res_info, NULL);
+  ret = ml_agent_resource_get ("test-res", &res_info);
   EXPECT_EQ (ret, 0);
 
   str = (res_info != NULL) ? strstr (res_info, "/path/res1.dat") : NULL;
@@ -532,7 +531,7 @@ TEST_F (MLAgentTest, resource)
   g_free (res_info);
   res_info = NULL;
 
-  ret = ml_agent_resource_delete ("test-res", NULL);
+  ret = ml_agent_resource_delete ("test-res");
   EXPECT_EQ (ret, 0);
 }
 
@@ -543,13 +542,13 @@ TEST_F (MLAgentTest, resource_add_01_n)
 {
   gint ret;
 
-  ret = ml_agent_resource_add (NULL, "/path/res.dat", NULL, NULL, NULL);
+  ret = ml_agent_resource_add (NULL, "/path/res.dat", NULL, NULL);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_resource_add ("", "/path/res.dat", NULL, NULL, NULL);
+  ret = ml_agent_resource_add ("", "/path/res.dat", NULL, NULL);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_resource_add ("test-res", NULL, NULL, NULL, NULL);
+  ret = ml_agent_resource_add ("test-res", NULL, NULL, NULL);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_resource_add ("test-res", "", NULL, NULL, NULL);
+  ret = ml_agent_resource_add ("test-res", "", NULL, NULL);
   EXPECT_NE (ret, 0);
 }
 
@@ -560,13 +559,13 @@ TEST_F (MLAgentTest, resource_delete_01_n)
 {
   gint ret;
 
-  ret = ml_agent_resource_delete (NULL, NULL);
+  ret = ml_agent_resource_delete (NULL);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_resource_delete ("", NULL);
+  ret = ml_agent_resource_delete ("");
   EXPECT_NE (ret, 0);
 
   /* no registered resource */
-  ret = ml_agent_resource_delete ("test-res", NULL);
+  ret = ml_agent_resource_delete ("test-res");
   EXPECT_NE (ret, 0);
 }
 
@@ -578,15 +577,15 @@ TEST_F (MLAgentTest, resource_get_01_n)
   gint ret;
   gchar *res_info = NULL;
 
-  ret = ml_agent_resource_get (NULL, &res_info, NULL);
+  ret = ml_agent_resource_get (NULL, &res_info);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_resource_get ("", &res_info, NULL);
+  ret = ml_agent_resource_get ("", &res_info);
   EXPECT_NE (ret, 0);
-  ret = ml_agent_resource_get ("test-res", NULL, NULL);
+  ret = ml_agent_resource_get ("test-res", NULL);
   EXPECT_NE (ret, 0);
 
   /* no registered resource */
-  ret = ml_agent_resource_get ("test-res", &res_info, NULL);
+  ret = ml_agent_resource_get ("test-res", &res_info);
   EXPECT_NE (ret, 0);
 }
 


### PR DESCRIPTION
This patch cuts the dependency on glib.h in the mlops-agent-interface.h.

Signed-off-by: Wook Song <wook16.song@samsung.com>

### Changes in this PR
#### v1
- All the arguments for ```GError **``` are changed to NULL.
- The ```GError **``` parameter of the wrappers for ```*_proxy_new_for_bus``` is removed.