### PR TITLE
Fix multiple memory leaks in daemon shutdown and JSON handling

### DIFF
--- a/daemon/gdbus-util.c
+++ b/daemon/gdbus-util.c
@@ -18,6 +18,7 @@
 #include "log.h"
 
 static GDBusConnection *g_dbus_sys_conn = NULL;
+static guint g_dbus_name_owner_id = 0;
 
 /**
  * @brief Export the DBus interface at the Object path on the bus connection.
@@ -56,11 +57,14 @@ name_acquired_cb (GDBusConnection * connection,
 int
 gdbus_get_name (const char *name)
 {
-  guint id;
+  if (g_dbus_name_owner_id > 0) {
+    g_bus_unown_name (g_dbus_name_owner_id);
+    g_dbus_name_owner_id = 0;
+  }
 
-  id = g_bus_own_name_on_connection (g_dbus_sys_conn, name,
+  g_dbus_name_owner_id = g_bus_own_name_on_connection (g_dbus_sys_conn, name,
       G_BUS_NAME_OWNER_FLAGS_NONE, name_acquired_cb, NULL, NULL, NULL);
-  if (id == 0)
+  if (g_dbus_name_owner_id == 0)
     return -ENOSYS;
 
   return 0;
@@ -140,6 +144,11 @@ gdbus_get_system_connection (gboolean is_session)
 void
 gdbus_put_system_connection (void)
 {
+  if (g_dbus_name_owner_id > 0) {
+    g_bus_unown_name (g_dbus_name_owner_id);
+    g_dbus_name_owner_id = 0;
+  }
+
   g_clear_object (&g_dbus_sys_conn);
 }
 

--- a/daemon/mlops-agent-interface.c
+++ b/daemon/mlops-agent-interface.c
@@ -58,10 +58,12 @@ _resolve_rpk_path_in_json (const char *json_str)
 
   if (n == 0U) {
     ml_loge ("No data found in the given json string.");
-    return NULL;
+    goto out_err;
   }
 
   for (i = 0; i < n; ++i) {
+    app_info_node = NULL;
+
     if (array) {
       object = json_array_get_object_element (array, i);
     } else {
@@ -70,7 +72,7 @@ _resolve_rpk_path_in_json (const char *json_str)
 
     if (!object) {
       ml_loge ("Failed to parse given json string.");
-      return NULL;
+      goto out_err;
     }
 
     app_info = json_object_get_string_member (object, "app_info");
@@ -88,7 +90,6 @@ _resolve_rpk_path_in_json (const char *json_str)
     app_info_object = json_node_get_object (app_info_node);
     if (!app_info_object) {
       ml_loge ("Failed to get `app_info` object.");
-      json_node_free (app_info_node);
       goto done;
     }
 
@@ -103,7 +104,6 @@ _resolve_rpk_path_in_json (const char *json_str)
       if (app_get_res_control_global_resource_path (res_type,
           &global_resource_path) != APP_ERROR_NONE) {
             ml_loge ("failed to get global resource path.");
-            json_node_free (app_info_node);
             goto done;
       }
 
@@ -113,13 +113,25 @@ _resolve_rpk_path_in_json (const char *json_str)
     }
 
     json_node_free (app_info_node);
+    app_info_node = NULL;
   }
 
 done:
+  if (app_info_node)
+    json_node_free (app_info_node);
+
   ret_json_str = json_to_string (node, TRUE);
   json_node_free (node);
 
   return ret_json_str;
+
+out_err:
+  if (app_info_node)
+    json_node_free (app_info_node);
+  if (node)
+    json_node_free (node);
+
+  return NULL;
 }
 #else
 static char *

--- a/daemon/modules.c
+++ b/daemon/modules.c
@@ -78,4 +78,7 @@ exit_modules (void *data)
     if (module->exit)
       module->exit (data);
   }
+
+  g_list_free (module_head);
+  module_head = NULL;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix a leak in `_resolve_rpk_path_in_json()` by adding cleanup on early-return/error paths so allocated `JsonNode` objects are released
- store and release DBus name ownership IDs to avoid leaking name-owner handles created via `g_bus_own_name_on_connection()`
- free module list nodes in `exit_modules()` to release `GList` allocations during daemon shutdown
- rewrite each leak-fix commit message to include a per-commit summary body and `Signed-off-by`

## Commits
- `0433857` Fix JSON node leak on early return paths
- `63abac7` Release DBus name owner to avoid handle leak
- `9a6f976` Free module list nodes during shutdown

## Validation
- attempted local build/test with `meson setup build && meson test -C build`
- environment limitation: `meson` is not installed on this runner (`meson: command not found`)

## Notes
- no changes were made to underlying external libraries (e.g., gstreamer, glibc)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9069e2b1-ca0e-43eb-b5ef-b04919b6a929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9069e2b1-ca0e-43eb-b5ef-b04919b6a929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

