### PR TITLE
[spec] Change db file install path from user.img to system-data.img

### DIFF
--- a/packaging/mlops-agent.spec
+++ b/packaging/mlops-agent.spec
@@ -169,7 +169,7 @@ meson setup --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --
 	--bindir=%{_bindir} --includedir=%{_includedir} \
 	%{enable_test} %{install_test} %{?testcoverage:-Db_coverage=true} \
 	%{?with_tizen:-Denable-tizen=true} \
-	-Dservice-db-path=%{?with_tizen:%{TZ_SYS_GLOBALUSER_DB}}%{!?with_tizen:%{expand:%{?service_db_path}}%{?!service_db_path:.}} \
+	-Dservice-db-path=%{?with_tizen:%{TZ_SYS_DB}}%{!?with_tizen:%{expand:%{?service_db_path}}%{?!service_db_path:.}} \
 	%{service_db_key_prefix} \
 	%{builddir}
 


### PR DESCRIPTION
- change db file path from `/opt/usr/dbspace` to `/opt/dbspace` by replacing
- `TZ_SYS_GLOBALUSER_DATA` -> `TZ_SYS_DATA`

REF:
https://review.tizen.org/gerrit/c/platform/core/system/resourced/+/341905
https://review.tizen.org/gerrit/c/platform/core/appfw/sppc/+/342990